### PR TITLE
Patch for mac

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,6 @@ import pycountry
 import requests
 import sys
 import subprocess
-import pathlib
 import json
 from huggingface_hub.hf_api import repo_exists as is_valid_model_id
 from PIL import Image, ImageTk

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,29 +1,20 @@
 batchalign
-ffmpeg-python==0.2.0
-huggingface-hub
-MarkupSafe
-matplotlib
-matplotlib-inline
-multiprocess
-narwhals
+# required to install omegaconf as a dependency of batchalign, but for some reason they dont have it in their requirements list
 omegaconf
-openai-whisper
-pandas
-pillow
-regex
-requests
-sacremoses
-safetensors
-scikit-learn
-scipy
-texterrors
-tqdm
-transformers
-urllib3
+
+ffmpeg-python==0.2.0
+
 #### dont install torch, torchvision, and torchaudio by default
 # torch
 # torchvision
 # torchaudio
-# nemo-toolkit
-#### if we fail on nemo-toolkit (I've seen this happen for windowa) comment the line above and uncomment the line below (line starting with # is a commented line)
-nemo-toolkit @ git+https://github.com/NVIDIA/NeMo.git@main
+
+# broken:
+# nemo-toolkit # broken by default, install directly from specific branch on the repo
+# @todo in the future, when the 2.4.x branch moves to main, update the requirements.txt to use main instead (main is on 2.3.2 @ 2025-07-21)
+nemo-toolkit @ git+https://github.com/NVIDIA/NeMo.git@v2.4.0rc2
+# required to install texterrors by default as it as a dependency of nemo-toolkit, but for some reason they dont have it in their requirements list
+texterrors
+
+# unused:
+# multiprocess


### PR DESCRIPTION
update imports and use nemo 2.4.x because it has some of the patches we have been waiting for. 

@todo watch https://github.com/NVIDIA/NeMo to see when their main branch brings in the 2.4 changes